### PR TITLE
Fix scroll position after refresh

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -28,6 +28,14 @@ export default function Home() {
       easing: "ease-in-out",
       once: true,
     });
+    
+    // Reset scroll position to top on page load/refresh
+    window.scrollTo(0, 0);
+    
+    // Disable browser's scroll restoration
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = 'manual';
+    }
   },[])
 
   return (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Reset scroll position to top on page refresh to match initial page load behavior.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The browser's default scroll restoration behavior keeps the scroll position on refresh. This change explicitly scrolls to the top and disables browser restoration to ensure the page always loads at the top, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4418871-a48f-4cb3-afb4-540681b39c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4418871-a48f-4cb3-afb4-540681b39c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>