### PR TITLE
Fix navbar full width display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -56,6 +56,13 @@
 }
 
 /* Base Styles */
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  overflow-x: hidden;
+}
+
 body {
   color: var(--foreground);
   background: linear-gradient(135deg, 
@@ -160,9 +167,15 @@ h1, h2, h3, h4, h5, h6 {
     }
   }
   
-  /* Ensure navbar has solid background */
+  /* Ensure navbar has solid background and spans full width */
   header.backdrop-blur-glass {
     background: rgba(10, 14, 39, 0.98) !important;
+    width: 100vw !important;
+    min-width: 100vw !important;
+    left: 0 !important;
+    right: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
   }
 
   .card-glass {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -167,7 +167,7 @@ export default function Home() {
       <WaterRipple />
 
       {/* Professional Header with Improved Mobile Navigation */}
-      <header className="fixed inset-x-0 top-0 z-50 backdrop-blur-glass border-b border-ocean-bright/20 shadow-lg w-full bg-ocean-deep/95">
+      <header className="fixed top-0 left-0 right-0 z-50 backdrop-blur-glass border-b border-ocean-bright/20 shadow-lg bg-ocean-deep/95">
         <div className="w-full flex h-16 sm:h-20 items-center justify-between px-4 sm:px-6 lg:px-8">
           {/* Logo */}
           <ScrollLink


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes the navbar background not extending to full width by adjusting CSS and HTML positioning.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The navbar's dark blue background was not spanning the full viewport width due to conflicting CSS rules and positioning. This PR explicitly sets `left-0 right-0` on the header in `page.js` and adds `width: 100vw !important`, `min-width: 100vw !important`, `left: 0 !important`, `right: 0 !important`, and `margin: 0 !important; padding: 0 !important` to the `header.backdrop-blur-glass` rule in `globals.css`. Additionally, `html, body` styles were reset to prevent default margins/padding from interfering with full-width elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bab2026-97b1-48af-8cc5-906602c3c828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8bab2026-97b1-48af-8cc5-906602c3c828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>